### PR TITLE
Remove TS type checking and add couple of @ts-ignores

### DIFF
--- a/packages/flex-plugin-webpack/src/devServer/webpackDevServer.ts
+++ b/packages/flex-plugin-webpack/src/devServer/webpackDevServer.ts
@@ -21,19 +21,17 @@ export default (devCompiler: Compiler, devConfig: Configuration, type: WebpackTy
 
   const devServer = new WebpackDevServer(devCompiler, devConfig);
 
-  /*
-   * if (!isStaticServer) {
-   *   // Show TS errors on browser
-   *   devCompiler.hooks.tsCompiled.tap('afterTSCompile', (warnings, errors) => {
-   *     if (warnings.length) {
-   *       devServer.sockWrite(devServer.sockets, 'warnings', warnings);
-   *     }
-   *     if (errors.length) {
-   *       devServer.sockWrite(devServer.sockets, 'errors', errors);
-   *     }
-   *   });
-   * }
-   */
+  if (!isStaticServer) {
+    // Show TS errors on browser
+    devCompiler.hooks.tsCompiled.tap('afterTSCompile', (warnings, errors) => {
+      if (warnings.length) {
+        devServer.sockWrite(devServer.sockets, 'warnings', warnings);
+      }
+      if (errors.length) {
+        devServer.sockWrite(devServer.sockets, 'errors', errors);
+      }
+    });
+  }
 
   // Start the dev-server
   devServer.listen(local.port, local.host, async (err) => {

--- a/packages/flex-plugin-webpack/src/devServer/webpackDevServer.ts
+++ b/packages/flex-plugin-webpack/src/devServer/webpackDevServer.ts
@@ -17,21 +17,8 @@ export default (devCompiler: Compiler, devConfig: Configuration, type: WebpackTy
   const port = env.getPort();
   const { local } = getLocalAndNetworkUrls(port);
   const isJavaScriptServer = type === WebpackType.JavaScript;
-  const isStaticServer = type === WebpackType.Static;
 
   const devServer = new WebpackDevServer(devCompiler, devConfig);
-
-  if (!isStaticServer) {
-    // Show TS errors on browser
-    devCompiler.hooks.tsCompiled.tap('afterTSCompile', (warnings, errors) => {
-      if (warnings.length) {
-        devServer.sockWrite(devServer.sockets, 'warnings', warnings);
-      }
-      if (errors.length) {
-        devServer.sockWrite(devServer.sockets, 'errors', errors);
-      }
-    });
-  }
 
   // Start the dev-server
   devServer.listen(local.port, local.host, async (err) => {

--- a/packages/flex-plugin-webpack/src/webpack/pnpTs.ts
+++ b/packages/flex-plugin-webpack/src/webpack/pnpTs.ts
@@ -24,6 +24,7 @@ export const resolveModuleName = (
   compilerOptions: CompilerOptions,
   resolutionHost: ModuleResolutionHost,
 ) => {
+  // @ts-ignore - mismatched TS versions
   return resolver(moduleName, containingFile, compilerOptions, resolutionHost, typescript.resolveModuleName);
 };
 
@@ -34,6 +35,7 @@ export const resolveTypeReferenceDirective = (
   compilerOptions: CompilerOptions,
   resolutionHost: ModuleResolutionHost,
 ) => {
+  // @ts-ignore
   return resolver(moduleName, containingFile, compilerOptions, resolutionHost, typescript.resolveModuleName);
 };
 


### PR DESCRIPTION
Our plugin has a newer version of typescript, and when we run this from inside the other process it comes up with all sorts of errors due to the version mismatch.

We could downgrade the version of Typescript in our plugin or upgrade it here if we wanted. 